### PR TITLE
Adding rspec support for several command line options

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source :rubygems
 gemspec
+gem "hpricot"
 
 group :development do
   gem 'rake'

--- a/bin/parallel_split_test
+++ b/bin/parallel_split_test
@@ -2,6 +2,8 @@
 require "optparse"
 $LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
 
+options = []
+
 parser = OptionParser.new do |opts|
   opts.banner = <<BANNER
 Split a big test file into multiple chunks and run them in parallel, giving ENV['TEST_ENV_NUMBER'] ('', '2', '3', ...)
@@ -11,8 +13,49 @@ Usage:
 
 Options are:
 BANNER
-  opts.on("-v", "--version", "Show Version"){ require 'parallel_split_test/version'; puts ParallelSplitTest::VERSION; exit}
-  opts.on("-h", "--help", "Show this.") { puts opts; exit }
+  opts.on("-v", "--version", "Display the version."){ require 'parallel_split_test/version'; puts ParallelSplitTest::VERSION; exit}
+  opts.on("-h", "--help", "You're looking at it.") { puts opts; exit }
+
+  opts.on( "-r", "--require FILE", "Require a file." ) do |path|
+    options << "--require"
+    options << path
+  end
+
+  opts.on("-f", "--format FORMATTER", "Choose a formatter.",
+                "  [p]rogress (default - dots)",
+                "  [d]ocumentation (group and example names)",
+                "  [h]tml",
+                "  [t]extmate",
+                "  [j]son",
+                "  custom formatter class name") do |o|
+    options << "--format"
+    options << o
+  end
+
+  opts.on("-o", "--out FILE",
+                    "Write output to a file instead of STDOUT. This option applies",
+                    "  to the previously specified --format, or the default format",
+                    "  if no format is specified."
+                   ) do |o|
+    options << "--out"
+    options << o
+  end
+
+  opts.on("-e", "--example STRING", "Run examples whose full nested names include STRING (may be",
+                                            "  used more than once)") do |o|
+    options << "--example"
+    options << o
+  end
+
+  opts.on('-t', '--tag TAG[:VALUE]',
+            'Run examples with the specified tag, or exclude examples',
+            'by adding ~ before the tag.',
+            '  - e.g. ~slow',
+            '  - TAG is always converted to a symbol') do |tag|
+    options << "--tag"
+    options << tag
+  end
+
 end
 
 parser.parse!
@@ -23,4 +66,4 @@ if ARGV.empty?
 end
 
 require 'parallel_split_test/runner'
-exit ParallelSplitTest::Runner.run(ARGV)
+exit ParallelSplitTest::Runner.run([ARGV, options].flatten)

--- a/lib/parallel_split_test/runner.rb
+++ b/lib/parallel_split_test/runner.rb
@@ -1,18 +1,21 @@
 require 'parallel_split_test/command_line'
+require 'fileutils'
+require 'hpricot'
+require "rexml/document"
 
 # a cleaned up version of the RSpec runner, e.g. no drb support
 module ParallelSplitTest
   class Runner < RSpec::Core::Runner
     def self.run(args, err=$stderr, out=$stdout)
       trap_interrupt
-      options = RSpec::Core::ConfigurationOptions.new(args)
-      options.parse_options
+
+      @args = args
 
       ParallelSplitTest.choose_number_of_processes
       out.puts "Running examples in #{ParallelSplitTest.processes} processes"
 
       report_execution_time(out) do
-        ParallelSplitTest::CommandLine.new(options).run(err, out)
+        ParallelSplitTest::CommandLine.new(args).run(err, out)
       end
     ensure
       RSpec.reset
@@ -23,7 +26,96 @@ module ParallelSplitTest
       result = yield
       runtime = Time.now.to_f - start
       out.puts "Took %.2f seconds with #{ParallelSplitTest.processes} processes" % runtime
+      merge_output
       result
     end
+
+    def self.merge_output
+
+      return if @args.index("--out").nil?
+
+      # Choose merge strategy based on format
+      if !@args.index("--format").nil?
+        case @args[@args.index("--format") + 1]
+        when "JUnit"
+          junit_merge
+        else
+          basic_merge
+        end
+      else
+        basic_merge
+      end
+
+    end
+
+    def self.junit_merge
+
+      output       = @args[@args.index("--out")+1]
+      path_defined = output.rindex("/")
+      folder       = path_defined.nil? ? "." : output[0...(output.rindex("/"))]
+      file         = path_defined.nil? ? output : output[(output.rindex("/"))+1..output.length]
+
+      errors   = 0
+      failures = 0
+      skipped  = 0
+      tests    = 0
+      time     = 0
+      cases    = []
+
+      xml_files = []
+      Dir.entries(folder).each do |element|
+        xml_files << element if element.start_with?(file)
+      end
+
+      xml_files.each do |xml_file|
+
+        # Collect the test cases
+        temp = File.new("#{folder}/#{xml_file}")
+        hdoc = Hpricot::XML(temp)
+        (hdoc/:testcase).each { |testcase| cases << testcase }
+
+        # Add up the attributes
+        temp = File.new("#{folder}/#{xml_file}")
+        xdoc = REXML::Document.new temp
+        xdoc.elements.each("testsuite") do |element|
+          errors   += element.attributes["errors"].to_i
+          failures += element.attributes["failures"].to_i
+          skipped  += element.attributes["skipped"].to_i
+          tests    += element.attributes["tests"].to_i
+          time     += element.attributes["time"].to_f
+        end
+
+        File.delete("#{folder}/#{xml_file}")
+
+      end
+
+      # Write the final merged results.xml
+      results = File.new("#{output}", "w")
+      results.write("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+      results.write("<testsuite errors=\"#{errors}\" failures=\"#{failures}\" skipped=\"#{skipped}\" tests=\"#{tests}\" time=\"#{time}\">\n")
+      results.write("  <properties/>\n")
+      cases.each { |tc| results.write("  #{tc}\n") }
+      results.write("</testsuite>")
+      results.close
+
+    end
+
+    def self.basic_merge
+
+      output       = @args[@args.index("--out")+1]
+      path_defined = output.rindex("/")
+      folder       = path_defined.nil? ? "." : output[0...(output.rindex("/"))]
+      file         = path_defined.nil? ? output : output[(output.rindex("/"))+1..output.length]
+
+      generic_files = []
+      Dir.entries(folder).each do |element|
+        generic_files << element if element.start_with?(file)
+      end
+
+      File.open("#{output}","w"){|f|f.puts generic_files.map{|nm|IO.read nm}}
+      generic_files.each{|f|File.delete(f) if f != output}
+
+    end
+
   end
 end

--- a/parallel_split_test.gemspec
+++ b/parallel_split_test.gemspec
@@ -11,5 +11,6 @@ Gem::Specification.new name, ParallelSplitTest::VERSION do |s|
   s.executables = ["parallel_split_test"]
   s.add_dependency "rspec", ">=2"
   s.add_dependency "parallel", ">=0.5.13"
+  s.add_dependency "hpricot"
   s.license = "MIT"
 end


### PR DESCRIPTION
I've added support for several rspec options, including:
- --require
- --format
- --out
- --example
- --tag
  I've simply ported over the descriptions from the original rspec/core/option_parser.rb.

The workaround for supporting --out is to write the output to several files and then merge the results together after test execution.

Let me know if you see anything out of the ordinary. If not, please pull into the master repo and then apply to the gem. I'm new to Ruby and gems, so I'm not sure how the gems are republished after updating code.
