### PR TITLE
Support tty? and closed? for ourput_recorder

### DIFF
--- a/lib/parallel_split_test/output_recorder.rb
+++ b/lib/parallel_split_test/output_recorder.rb
@@ -7,7 +7,7 @@ module ParallelSplitTest
       @out = out
     end
 
-    %w[puts write print putc flush tty?].each do |method|
+    %w[puts write print putc flush tty? closed?].each do |method|
       class_eval <<-RUBY, __FILE__, __LINE__
         def #{method}(*args)
           @recorded.#{method}(*args)

--- a/lib/parallel_split_test/output_recorder.rb
+++ b/lib/parallel_split_test/output_recorder.rb
@@ -7,7 +7,7 @@ module ParallelSplitTest
       @out = out
     end
 
-    %w[puts write print putc flush].each do |method|
+    %w[puts write print putc flush tty?].each do |method|
       class_eval <<-RUBY, __FILE__, __LINE__
         def #{method}(*args)
           @recorded.#{method}(*args)


### PR DESCRIPTION
These methods are needed to run parallel_split_test with [Fuubar](https://github.com/thekompanee/fuubar) or Progress formatter.
If not supported, `undefined method 'tty?'` error or `undefined method 'closed?'` error occurs.