### PR TITLE
Put out files into the same directory as the actual.

### DIFF
--- a/lib/parallel_split_test/command_line.rb
+++ b/lib/parallel_split_test/command_line.rb
@@ -40,7 +40,7 @@ module ParallelSplitTest
 
     # modify + reparse args to unify output
     def modify_out_file_in_args(process_number)
-      @args[out_file_position] = "#{out_file_basename}.#{process_number}#{File.extname(out_file)}"
+      @args[out_file_position] = "#{out_file_parent_dir}/#{out_file_basename}.#{process_number}#{File.extname(out_file)}"
       @options = RSpec::Core::ConfigurationOptions.new(@args)
     end
 
@@ -50,6 +50,10 @@ module ParallelSplitTest
 
     def out_file
       @out_file ||= @args[out_file_position] if out_file_position
+    end
+
+    def out_file_parent_dir
+      @out_file_parent_dir ||= File.expand_path("#{out_file}/../.")
     end
 
     def out_file_basename
@@ -66,7 +70,7 @@ module ParallelSplitTest
 
     def combine_out_files
       File.open(out_file, "w") do |f|
-        Dir["#{out_file_basename}.*#{File.extname(out_file)}"].each do |file|
+        Dir["#{out_file_parent_dir}/#{out_file_basename}.*#{File.extname(out_file)}"].each do |file|
           f.write File.read(file)
           File.delete(file)
         end

--- a/spec/parallel_split_test_spec.rb
+++ b/spec/parallel_split_test_spec.rb
@@ -283,6 +283,7 @@ describe ParallelSplitTest do
             end
           end
         RUBY
+        run "mkdir -p output"
         result = parallel_split_test "xxx_spec.rb --format d --out output/xxx.xml --no-merge"
         # output does not show up in stdout
         expect(result).not_to include "xxx"

--- a/spec/parallel_split_test_spec.rb
+++ b/spec/parallel_split_test_spec.rb
@@ -283,7 +283,7 @@ describe ParallelSplitTest do
             end
           end
         RUBY
-        result = parallel_split_test "xxx_spec.rb --format d --out xxx.xml --no-merge"
+        result = parallel_split_test "xxx_spec.rb --format d --out output/xxx.xml --no-merge"
         # output does not show up in stdout
         expect(result).not_to include "xxx"
         expect(result).not_to include "yyy"
@@ -292,7 +292,7 @@ describe ParallelSplitTest do
         expect(result).to include "Running examples in"
 
         # two separate out files remain
-        expect(Dir["xxx.*.xml"].sort!).to eq(["xxx.0.xml", "xxx.1.xml"].sort!)
+        expect(Dir["output/xxx.*.xml"].sort!).to eq(["output/xxx.0.xml", "output/xxx.1.xml"].sort!)
       end
     end
   end


### PR DESCRIPTION
### Motivation
When specifying the output path which is different path from the current, I want the output of child processes to be put into the same path as the parent  if `--no-merge` option exists.