### PR TITLE
Switch gemspec dependency from rspec to rspec-core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ gemspec
 
 gem "rake"
 gem "bump"
+gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     parallel_split_test (0.8.0)
       parallel (>= 0.5.13)
-      rspec (>= 3.1.0)
+      rspec-core (>= 3.1.0)
 
 GEM
   remote: https://rubygems.org/
@@ -33,6 +33,7 @@ DEPENDENCIES
   bump
   parallel_split_test!
   rake
+  rspec
 
 BUNDLED WITH
    2.1.4

--- a/lib/parallel_split_test/command_line.rb
+++ b/lib/parallel_split_test/command_line.rb
@@ -1,7 +1,7 @@
 require 'parallel_split_test'
 require 'parallel_split_test/output_recorder'
 require 'parallel'
-require 'rspec'
+require 'rspec/core'
 require 'parallel_split_test/core_ext/rspec_world'
 
 module ParallelSplitTest

--- a/parallel_split_test.gemspec
+++ b/parallel_split_test.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new name, ParallelSplitTest::VERSION do |s|
   s.homepage = "https://github.com/grosser/#{name}"
   s.files = `git ls-files lib bin Readme.md`.split("\n")
   s.executables = ["parallel_split_test"]
-  s.add_dependency "rspec", ">=3.1.0"
+  s.add_dependency "rspec-core", ">=3.1.0"
   s.add_dependency "parallel", ">=0.5.13"
   s.license = "MIT"
   s.required_ruby_version = '>= 2.2.0'


### PR DESCRIPTION
So that projects that don't use the other rspec packages can use `parallel_split_test` without pulling in those packages regardless.

The `rspec` dependency was added explicitly to this repository's `Gemfile`, since the tests here use `rspec-expectations`.