### PR TITLE
feat: Add Ruby 3.3 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['3.0', '3.1', '3.2', '3.3']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rspec spec/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 rvm:
-  - 2.2
-  - 2.4
-  - 2.5
-  - 2.6
+  - 3.0
+  - 3.1
+  - 3.2
+  - 3.3
 branches:
   only: master
 before_install: ruby -e "File.write('Gemfile.lock', File.read('Gemfile.lock').split('BUNDLED WITH').first)"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,32 +1,33 @@
 PATH
   remote: .
   specs:
-    parallel_split_test (0.10.0)
-      parallel (>= 0.5.13)
+    parallel_split_test (0.11.0)
+      parallel (>= 1.20.0)
       rspec-core (>= 3.9.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    bump (0.8.0)
-    diff-lcs (1.4.4)
-    parallel (1.20.1)
-    rake (12.3.2)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.2)
-      rspec-support (~> 3.9.3)
-    rspec-expectations (3.9.2)
+    bump (0.10.0)
+    diff-lcs (1.6.2)
+    parallel (1.27.0)
+    rake (13.3.1)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.7)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.3)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.6)
 
 PLATFORMS
+  arm64-darwin-24
   ruby
 
 DEPENDENCIES
@@ -35,5 +36,17 @@ DEPENDENCIES
   rake
   rspec
 
+CHECKSUMS
+  bump (0.10.0) sha256=07929cf79031d2863f55e7b111e164566be10c43f8c42d67db7cb3b5745f0975
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  parallel (1.27.0) sha256=4ac151e1806b755fb4e2dc2332cbf0e54f2e24ba821ff2d3dcf86bf6dc4ae130
+  parallel_split_test (0.11.0)
+  rake (13.3.1) sha256=8c9e89d09f66a26a01264e7e3480ec0607f0c497a861ef16063604b1b08eb19c
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-mocks (3.13.7) sha256=0979034e64b1d7a838aaaddf12bf065ea4dc40ef3d4c39f01f93ae2c66c62b1c
+  rspec-support (3.13.6) sha256=2e8de3702427eab064c9352fe74488cc12a1bfae887ad8b91cba480ec9f8afb2
+
 BUNDLED WITH
-   2.1.4
+  4.0.3

--- a/lib/parallel_split_test/version.rb
+++ b/lib/parallel_split_test/version.rb
@@ -1,3 +1,3 @@
 module ParallelSplitTest
-  VERSION = '0.10.0'
+  VERSION = '0.11.0'
 end

--- a/parallel_split_test.gemspec
+++ b/parallel_split_test.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new name, ParallelSplitTest::VERSION do |s|
   s.files = `git ls-files lib bin Readme.md`.split("\n")
   s.executables = ["parallel_split_test"]
   s.add_dependency "rspec-core", ">= 3.9.0"
-  s.add_dependency "parallel", ">= 0.5.13"
+  s.add_dependency "parallel", ">= 1.20.0"
   s.license = "MIT"
   s.required_ruby_version = '>= 2.2.0'
 end


### PR DESCRIPTION
## Summary
- Update parallel dependency minimum to >= 1.20.0 for Ruby 3.x compatibility
- Add GitHub Actions workflow for CI testing Ruby 3.0, 3.1, 3.2, 3.3
- Update Travis CI configuration for Ruby 3.x
- Bump version to 0.11.0

## Test plan
- [x] Tests pass locally on Ruby 3.2.7
- [x] Tests pass locally on Ruby 3.3.10
- [ ] GitHub Actions CI passes for all Ruby versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)